### PR TITLE
feat: better errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and this project adheres to [Semantic Versioning].
 - `RowCol.index` field
 - `Parser.alt` takes the responsibility for `Parser.__or__`,
   which becomes a simple proxy
+- `ParseError` exception class, now the only exception raised to
+  user code on parse failure. It exposes structured `.err`, `.index`,
+  `.expected`, and `.location` attributes.
 
 ### Fixed
 
@@ -22,6 +25,9 @@ and this project adheres to [Semantic Versioning].
 - `Parser.skip` (`<<`) was returning the wrong index
 - `many` parser no longer relies on a magic upper-bound value
 - Better `eof`, `index` and `line_info` typing
+- `Err.aggregate` no longer merges expectations across different
+  stream positions — only the furthest error's expectations are kept,
+  producing cleaner error messages
 
 ### Changed
 
@@ -31,9 +37,20 @@ and this project adheres to [Semantic Versioning].
 - **Breaking:** `transform` parameter in `tag`, `string`, and
   `from_enum` defaults to `None` instead of `noop`; `tag` skips the
   transform call entirely when none is provided
+- **Breaking:** `Err` is now a plain dataclass, no longer an
+  `Exception`. Code that caught `Err` directly should catch
+  `ParseError` instead.
+- **Breaking:** `Err.expected` is now a `frozenset[str]` instead of
+  `list[str]`, deduplicating alternatives automatically
+- **Breaking:** `Err.location` is now `RowCol | int` instead of a
+  pre-formatted string, making errors machine-readable
+- **Breaking:** `Ok.ok_or_raise` / `Err.ok_or_raise` renamed to
+  `Ok.ok` / `Err.ok`
 - `Parser.until` gets a `return_other` parameter
 - Rename `Parser.until_discard` to `Parser.until_excluding`
+- Rename internal `SoftError` to `Backtrack` for clarity
 - Simplify `regex` parser, removing type-unsafe groups
+- All error construction sites now use `Err.from_stream`
 
 ### Removed
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ A motivating example:
 ```python
 import datetime
 
-from persil import from_stream, regex
+from persil import from_stream, regex, string, Stream
 
 year = regex("[0-9]{4}").map(int)
 month = regex("(0[0-9]|1[0-2])").map(int)
@@ -58,18 +58,22 @@ day = regex("([012][0-9]|3[01])").map(int)
 
 dash = string("-")
 
+
 @from_stream
-def date() -> datetime.date:
+def date(stream: Stream[str]) -> datetime.date:
     """
     Parse a date in the format YYYY-MM-DD
     """
-    y = stream(year)
-    stream(dash)
-    m = stream(month)
-    stream(dash)
-    d = stream(day)
+    y = stream.apply(year)
+    stream.apply(dash)
+    m = stream.apply(month)
+    stream.apply(dash)
+    d = stream.apply(day)
 
     return datetime.date(y, m, d)
+
+
+assert date.parse("1789-07-14") == datetime.date(year=1789, month=7, day=15)
 ```
 
 ### Lazy definition

--- a/docs/index.md
+++ b/docs/index.md
@@ -50,7 +50,7 @@ A motivating example:
 ```python
 import datetime
 
-from persil import from_stream, regex
+from persil import from_stream, regex, string, Stream
 
 year = regex("[0-9]{4}").map(int)
 month = regex("(0[0-9]|1[0-2])").map(int)
@@ -58,18 +58,22 @@ day = regex("([012][0-9]|3[01])").map(int)
 
 dash = string("-")
 
+
 @from_stream
-def date() -> datetime.date:
+def date(stream: Stream[str]) -> datetime.date:
     """
     Parse a date in the format YYYY-MM-DD
     """
-    y = stream(year)
-    stream(dash)
-    m = stream(month)
-    stream(dash)
-    d = stream(day)
+    y = stream.apply(year)
+    stream.apply(dash)
+    m = stream.apply(month)
+    stream.apply(dash)
+    d = stream.apply(day)
 
     return datetime.date(y, m, d)
+
+
+assert date.parse("1789-07-14") == datetime.date(year=1789, month=7, day=15)
 ```
 
 ### Lazy definition

--- a/src/persil/__init__.py
+++ b/src/persil/__init__.py
@@ -10,10 +10,12 @@ from .parsers import (
     tag,
     whitespace,
 )
+from .result import ParseError
 from .lazy import lazy
 from .stream import Stream, from_stream
 
 __all__ = [
+    "ParseError",
     "Parser",
     "Stream",
     "fail",

--- a/src/persil/parser.py
+++ b/src/persil/parser.py
@@ -4,7 +4,7 @@ from typing import Any, Callable, Sequence, cast, overload, Literal
 
 from persil.utils import Span, line_info_at
 
-from .result import Err, Ok, Result
+from .result import Err, Ok, ParseError, Result
 
 type Wrapped[In: Sequence, Out] = Callable[[In, int], Result[Out]]
 
@@ -42,7 +42,7 @@ class Parser[In: Sequence, Out]:
         @Parser
         def cut_parser(stream: In, index: int) -> Result[Out]:
             result = self(stream, index)
-            return result.ok_or_raise()
+            return result.ok()
 
         return cut_parser
 
@@ -182,7 +182,7 @@ class Parser[In: Sequence, Out]:
         result = self(stream, 0)
 
         if isinstance(result, Err):
-            raise result
+            raise ParseError(result)
 
         value = result.value
         remainder = cast(In, stream[result.index :])

--- a/src/persil/parsers/index.py
+++ b/src/persil/parsers/index.py
@@ -23,7 +23,7 @@ def line_info[In: (str, bytes)]() -> Parser[In, int]:
     """
 
     @Parser
-    def _line_info(stream: Sequence, index: int) -> Result[RowCol]:
+    def _line_info(stream: str | bytes, index: int) -> Result[RowCol]:
         return Ok(line_info_at(stream, index), index)
 
     return cast(Parser[In, int], _line_info)

--- a/src/persil/parsers/outcome.py
+++ b/src/persil/parsers/outcome.py
@@ -2,7 +2,6 @@ from typing import Sequence
 
 from persil import Parser
 from persil.result import Err, Result
-from persil.utils import line_info
 
 
 def fail(expected: str) -> Parser:
@@ -12,6 +11,6 @@ def fail(expected: str) -> Parser:
 
     @Parser
     def fail_parser(stream: Sequence, index: int) -> Result:
-        return Err(index, [expected], line_info(stream, index))
+        return Err.from_stream(index, expected, stream)
 
     return fail_parser

--- a/src/persil/parsers/regex.py
+++ b/src/persil/parsers/regex.py
@@ -2,7 +2,6 @@ import re
 
 from persil import Parser
 from persil.result import Err, Ok, Result
-from persil.utils import line_info
 
 
 def regex(
@@ -39,7 +38,7 @@ def regex(
         if match:
             return Ok(match.group(), match.end())
         else:
-            return Err(index, [exp.pattern], line_info(stream, index))
+            return Err.from_stream(index, exp.pattern, stream)
 
     return regex_parser
 
@@ -66,6 +65,6 @@ def regex_groupdict(
         if match:
             return Ok(match.groupdict(), match.end())
         else:
-            return Err(index, [exp.pattern], line_info(stream, index))
+            return Err.from_stream(index, exp.pattern, stream)
 
     return regex_groupdict_parser

--- a/src/persil/parsers/tag.py
+++ b/src/persil/parsers/tag.py
@@ -2,7 +2,6 @@ from typing import Any, Callable
 
 from persil import Parser
 from persil.result import Err, Ok, Result
-from persil.utils import line_info
 
 
 def tag[T: (str, bytes)](
@@ -34,7 +33,7 @@ def tag[T: (str, bytes)](
             matched = stream[index : index + slen]  # ty:ignore[invalid-argument-type]
             if transform(matched) == transformed_s:
                 return Ok(matched, index + slen)
-            return Err(index, [str(expected)], line_info(stream, index))
+            return Err.from_stream(index, str(expected), stream)
 
         return transformed_tag_parser
 
@@ -43,6 +42,6 @@ def tag[T: (str, bytes)](
         matched = stream[index : index + slen]  # ty:ignore[invalid-argument-type]
         if matched == expected:
             return Ok(matched, index + slen)
-        return Err(index, [str(expected)], line_info(stream, index))
+        return Err.from_stream(index, str(expected), stream)
 
     return tag_parser

--- a/src/persil/result.py
+++ b/src/persil/result.py
@@ -24,9 +24,9 @@ class Ok[T]:
     def ok(self) -> Ok[T]:
         """No-op: returns self.
 
-        Mirrors :meth:`Err.ok` so that :type:`Result` can be used
-        uniformly — calling ``.ok()`` on success is a no-op, while
-        calling it on failure raises :class:`ParseError`.
+        Mirrors `Err.ok` so that `Result` can be used
+        uniformly — calling `.ok()` on success is a no-op, while
+        calling it on failure raises `ParseError`.
         """
         return self
 
@@ -46,8 +46,7 @@ class Ok[T]:
 class Err:
     """A parse error carrying structured location and expectation info.
 
-    This is a plain dataclass — it is never raised directly. Use
-    :class:`ParseError` to convert it into a raisable exception.
+    Use `Self.raise_error()` to raise it wrapped into a `ParseError`.
     """
 
     index: int
@@ -61,11 +60,10 @@ class Err:
         expected: str,
         stream: Sequence,
     ) -> Self:
-        """Build an :class:`Err` from a stream position.
+        """Build an `Err` from a stream position.
 
-        For ``str`` and ``bytes`` streams the location is computed as a
-        :class:`RowCol`; for other sequence types it falls back to the
-        raw integer index.
+        For `str` and `bytes` streams the location is computed as a `RowCol`;
+        for other sequence types it falls back to the raw integer index.
         """
         if isinstance(stream, (str, bytes)):
             location: RowCol | int = line_info_at(stream, index)
@@ -79,22 +77,25 @@ class Err:
             return f"expected {items[0]} at {self.location}"
         return f"expected one of {', '.join(items)} at {self.location}"
 
-    def ok(self) -> Never:
-        """Raise as a :class:`ParseError`."""
+    def raise_error(self) -> Never:
+        """Raise a `ParseError`."""
         raise ParseError(self)
 
+    def ok(self) -> Never:
+        """Raise as a `ParseError`."""
+        self.raise_error()
+
     def map(self, map_function: Callable) -> Self:
-        """No-op: errors propagate unchanged through ``map``."""
+        """No-op: errors propagate unchanged through `map`."""
         return self
 
     def aggregate[T](self, other: Result[T]) -> Result[T]:
         """Merge two errors, keeping the one furthest into the stream.
 
-        If *other* is :class:`Ok`, it wins unconditionally.  When both
-        are :class:`Err`, the error at the higher index is kept.  If the
-        indices are equal, expectations from both branches are merged so
-        the message lists every alternative that was tried at that
-        position.
+        If *other* is `Ok`, it wins unconditionally. When both are `Err`,
+        the error at the higher index is kept. If the indices are equal,
+        expectations from both branches are merged so the message lists
+        every alternative that was tried at that position.
         """
         if isinstance(other, Ok):
             return other
@@ -118,8 +119,8 @@ class Err:
 class ParseError(Exception):
     """Raised when parsing fails.
 
-    Wraps an :class:`Err` so that structured error data is available
-    via the :attr:`err` attribute, while still being a proper exception.
+    Wraps an `Err` so that structured error data is available
+    via the `err` attribute, while still being a proper exception.
     """
 
     def __init__(self, err: Err) -> None:
@@ -143,4 +144,4 @@ class ParseError(Exception):
 
 
 type Result[T] = Ok[T] | Err
-"""The result of applying a parser: either :class:`Ok` or :class:`Err`."""
+"""The result of applying a parser: either `Ok` or `Err`."""

--- a/src/persil/result.py
+++ b/src/persil/result.py
@@ -1,23 +1,41 @@
 from __future__ import annotations
-from persil.utils import line_info
 
 from dataclasses import dataclass
 from typing import Callable, Never, Self, Sequence
 
+from persil.utils import RowCol, line_info_at
+
 
 @dataclass
 class Ok[T]:
+    """A successful parse result.
+
+    Attributes
+    ----------
+    value
+        The value produced by the parser.
+    index
+        The stream position immediately after the consumed input.
+    """
+
     value: T
     index: int
 
-    def ok_or_raise(self) -> Ok[T]:
-        """No-op function."""
+    def ok(self) -> Ok[T]:
+        """No-op: returns self.
+
+        Mirrors :meth:`Err.ok` so that :type:`Result` can be used
+        uniformly — calling ``.ok()`` on success is a no-op, while
+        calling it on failure raises :class:`ParseError`.
+        """
         return self
 
     def map[Out](self, map_function: Callable[[T], Out]) -> Ok[Out]:
+        """Apply *map_function* to the value, preserving the index."""
         return Ok(value=map_function(self.value), index=self.index)
 
     def with_index(self, index: int) -> Ok[T]:
+        """Return a copy with a different stream index."""
         return Ok(
             value=self.value,
             index=index,
@@ -25,44 +43,104 @@ class Ok[T]:
 
 
 @dataclass
-class Err(Exception):
+class Err:
+    """A parse error carrying structured location and expectation info.
+
+    This is a plain dataclass — it is never raised directly. Use
+    :class:`ParseError` to convert it into a raisable exception.
+    """
+
     index: int
-    expected: list[str]
-    location: str
+    expected: frozenset[str]
+    location: RowCol | int
 
     @classmethod
-    def from_stream[T: Sequence](
+    def from_stream(
         cls,
         index: int,
         expected: str,
-        stream: T,
+        stream: Sequence,
     ) -> Self:
-        location = line_info(stream, index)
-        return cls(index, [expected], location)
+        """Build an :class:`Err` from a stream position.
+
+        For ``str`` and ``bytes`` streams the location is computed as a
+        :class:`RowCol`; for other sequence types it falls back to the
+        raw integer index.
+        """
+        if isinstance(stream, (str, bytes)):
+            location: RowCol | int = line_info_at(stream, index)
+        else:
+            location = index
+        return cls(index, frozenset({expected}), location)
 
     def __str__(self) -> str:
-        if len(self.expected) == 1:
-            return f"expected {self.expected[0]} at {self.location}"
-        else:
-            return f"expected one of {', '.join(self.expected)} at {self.location}"
+        items = sorted(self.expected)
+        if len(items) == 1:
+            return f"expected {items[0]} at {self.location}"
+        return f"expected one of {', '.join(items)} at {self.location}"
 
-    def ok_or_raise(self) -> Never:
-        """Raise the error directly"""
-        raise self
+    def ok(self) -> Never:
+        """Raise as a :class:`ParseError`."""
+        raise ParseError(self)
 
     def map(self, map_function: Callable) -> Self:
+        """No-op: errors propagate unchanged through ``map``."""
         return self
 
     def aggregate[T](self, other: Result[T]) -> Result[T]:
+        """Merge two errors, keeping the one furthest into the stream.
+
+        If *other* is :class:`Ok`, it wins unconditionally.  When both
+        are :class:`Err`, the error at the higher index is kept.  If the
+        indices are equal, expectations from both branches are merged so
+        the message lists every alternative that was tried at that
+        position.
+        """
         if isinstance(other, Ok):
             return other
 
-        # Keep the error that is furthest into the stream; its location string
-        # already corresponds to that index.
-        if self.index >= other.index:
-            return Err(self.index, self.expected + other.expected, self.location)
-        else:
-            return Err(other.index, self.expected + other.expected, other.location)
+        # Keep only the error that is furthest into the stream.
+        # Expectations from an earlier index are irrelevant — they
+        # describe what was expected at a position already parsed past.
+        if self.index > other.index:
+            return self
+        if self.index < other.index:
+            return other
+
+        # Same index: merge expectations from both branches.
+        return Err(
+            self.index,
+            self.expected | other.expected,
+            self.location,
+        )
+
+
+class ParseError(Exception):
+    """Raised when parsing fails.
+
+    Wraps an :class:`Err` so that structured error data is available
+    via the :attr:`err` attribute, while still being a proper exception.
+    """
+
+    def __init__(self, err: Err) -> None:
+        self.err = err
+        super().__init__(str(err))
+
+    @property
+    def index(self) -> int:
+        """Stream index where the error occurred."""
+        return self.err.index
+
+    @property
+    def expected(self) -> frozenset[str]:
+        """Set of descriptions of what was expected at this position."""
+        return self.err.expected
+
+    @property
+    def location(self) -> RowCol | int:
+        """Structured location (row/col for text, raw index otherwise)."""
+        return self.err.location
 
 
 type Result[T] = Ok[T] | Err
+"""The result of applying a parser: either :class:`Ok` or :class:`Err`."""

--- a/src/persil/stream.py
+++ b/src/persil/stream.py
@@ -2,10 +2,20 @@ from functools import wraps
 from typing import Callable, Sequence, overload
 
 from .parser import Parser
-from .result import Err, Ok, Result
+from .result import Err, Ok, ParseError, Result
 
 
-class SoftError(Exception):
+class Backtrack(Exception):
+    """Control-flow signal raised by `Stream.apply` when a parser returns `Err`.
+
+    This is *not* a user-facing error. It is caught internally by `_from_stream`
+    to convert the failure back into a returned `Err`, allowing combinators
+    like `|` to try alternatives.
+
+    Contrast with `ParseError`, which represents a *committed* failure
+    (e.g. after `Parser.cut`) and is never caught by `_from_stream`.
+    """
+
     def __init__(self, inner: Err) -> None:
         self.inner = inner
         super().__init__()
@@ -26,7 +36,7 @@ class Stream[In: Sequence]:
         res = parser(self.inner, self.index)
 
         if isinstance(res, Err):
-            raise SoftError(res)
+            raise Backtrack(res)
 
         self.index = res.index
 
@@ -42,8 +52,12 @@ def _from_stream[In: Sequence, Out](
         st = Stream(inner=stream, index=index)
         try:
             out = func(st)
-        except SoftError as e:
+        except Backtrack as e:
             return e.inner
+        except ParseError:
+            # NOTE: A cut() inside the stream function raises ParseError;
+            # re-raise so it propagates past the caller.
+            raise
         return Ok(out, st.index)
 
     return fn

--- a/src/persil/stream.py
+++ b/src/persil/stream.py
@@ -12,8 +12,8 @@ class Backtrack(Exception):
     to convert the failure back into a returned `Err`, allowing combinators
     like `|` to try alternatives.
 
-    Contrast with `ParseError`, which represents a *committed* failure
-    (e.g. after `Parser.cut`) and is never caught by `_from_stream`.
+    By contrast, `ParseError` represents a *committed* failure (e.g. after `Parser.cut`)
+    and is never caught by `_from_stream`.
     """
 
     def __init__(self, inner: Err) -> None:
@@ -22,10 +22,10 @@ class Backtrack(Exception):
 
 
 class Stream[In: Sequence]:
-    """
-    The `Stream` API lets you apply parsers iteratively, and handles
-    the index bookeeping for you. Its design goal is to be used with
-    the `from_stream` decorator.
+    """Wrapper around the input to allow applying parsers sequentially while
+    maintaining the necessary bookeeping.
+
+    See `from_stream` for more information.
     """
 
     def __init__(self, inner: In, index: int = 0):
@@ -91,12 +91,12 @@ def from_stream[In: Sequence, Out](
         Parser[In, Out],
     ]
 ):
-    """Create a parser from a function that operates on a :class:`Stream`.
+    r"""Create a parser from a function that operates on a `Stream`.
 
     Can be used as a bare decorator, a decorator with a description, or
     called directly with a function and an optional description.
 
-    Examples::
+    Examples:
 
         @from_stream
         def my_parser(stream: Stream[str]) -> int: ...
@@ -105,6 +105,15 @@ def from_stream[In: Sequence, Out](
         def my_parser(stream: Stream[str]) -> int: ...
 
         parser = from_stream(my_func, desc="my parser")
+
+        @from_stream
+        def datetime_parser(stream: Stream[str]) -> datetime:
+            year = stream.apply(regex(r"\d{4}").map(int))
+            stream.apply(string("/"))
+            month = stream.apply(regex(r"\d{2}").map(int))
+            stream.apply(string("/"))
+            day = stream.apply(regex(r"\d{2}").map(int))
+            return datetime(year, month, day)
     """
 
     def _wrap(f: Callable[[Stream[In]], Out]) -> Parser[In, Out]:

--- a/src/persil/utils.py
+++ b/src/persil/utils.py
@@ -1,6 +1,5 @@
 from dataclasses import dataclass
 from functools import singledispatch
-from typing import Sequence
 
 
 @dataclass
@@ -23,7 +22,7 @@ class Span[T]:
 
 
 @singledispatch
-def line_info_at(stream: Sequence, index: int) -> RowCol:
+def line_info_at(stream: str | bytes, index: int) -> RowCol:
     raise TypeError
 
 
@@ -41,10 +40,3 @@ def _(stream: str, index: int) -> RowCol:
     last_nl = stream.rfind("\n", 0, index)
     col = index - (last_nl + 1)
     return RowCol(index, row, col)
-
-
-def line_info(stream: Sequence, index: int) -> str:
-    if isinstance(stream, (str, bytes)):
-        return str(line_info_at(stream, index))
-    else:
-        return str(index)

--- a/tests/test_from_enum.py
+++ b/tests/test_from_enum.py
@@ -4,7 +4,7 @@ import pytest
 from hypothesis import given, strategies as st
 
 from persil import from_enum
-from persil.result import Err
+from persil.result import ParseError
 
 
 class Defcon(enum.Enum):
@@ -39,7 +39,7 @@ def test_from_enum_empty_does_not_crash():
     # Constructing a parser from an empty enum must not raise IndexError.
     # Parsing any input should raise a parse error, not a Python exception.
     empty_parser = from_enum(EmptyEnum)
-    with pytest.raises(Err):
+    with pytest.raises(ParseError):
         empty_parser.parse("anything")
 
 

--- a/tests/test_parser_combinators.py
+++ b/tests/test_parser_combinators.py
@@ -3,7 +3,7 @@ from hypothesis import assume, given, strategies as st
 
 from persil import regex, string
 from persil.parser import eof
-from persil.result import Err
+from persil.result import Err, ParseError
 
 
 any_char = regex(r"[\s\S]")
@@ -16,7 +16,7 @@ def test_cut_success():
 
 def test_cut_raises_on_failure():
     parser = string("a").cut()
-    with pytest.raises(Err):
+    with pytest.raises(ParseError):
         parser.parse("b")
 
 
@@ -29,13 +29,13 @@ def test_cut_is_transparent_on_success(text: str):
 
 def test_skip_second_fails():
     parser = string("a").skip(string("b"))
-    with pytest.raises(Err):
+    with pytest.raises(ParseError):
         parser.parse("ac")
 
 
 def test_combine_second_fails():
     parser = string("a").combine(string("b"))
-    with pytest.raises(Err):
+    with pytest.raises(ParseError):
         parser.parse("ac")
 
 
@@ -99,7 +99,7 @@ def test_sep_by_max_zero():
 
 def test_should_fail_when_inner_succeeds():
     parser = string("a").should_fail("not 'a'")
-    with pytest.raises(Err):
+    with pytest.raises(ParseError):
         parser.parse("a")
 
 
@@ -125,13 +125,13 @@ def test_should_fail_inverts_success(text: str):
 
 def test_span_failure():
     parser = string("a").span()
-    with pytest.raises(Err):
+    with pytest.raises(ParseError):
         parser.parse("b")
 
 
 def test_add_second_fails():
     parser = string("a").times(1) + string("b").times(1)
-    with pytest.raises(Err):
+    with pytest.raises(ParseError):
         parser.parse("ac")
 
 
@@ -148,7 +148,7 @@ def test_add_concatenates_lists(n: int, m: int):
 
 
 def test_eof_not_at_end():
-    with pytest.raises(Err):
+    with pytest.raises(ParseError):
         eof().parse_partial("leftover")
 
 
@@ -180,6 +180,6 @@ def test_sep_by_result_length(count: int, min_val: int, max_val: int):
     try:
         result, _ = parser.parse_partial(text)
         assert min_val <= len(result) <= max_val
-    except Err:
+    except ParseError:
         # Expected when count < min_val.
         assert count < min_val

--- a/tests/test_regex.py
+++ b/tests/test_regex.py
@@ -4,7 +4,7 @@ import pytest
 from hypothesis import given, strategies as st
 
 from persil import regex
-from persil.result import Err
+from persil.result import ParseError
 from persil.parsers.regex import regex_groupdict
 
 
@@ -30,7 +30,7 @@ def test_regex_precompiled_str_pattern():
 
 
 def test_regex_no_match_raises():
-    with pytest.raises(Err):
+    with pytest.raises(ParseError):
         regex(r"\d+").parse("abc")
 
 
@@ -64,5 +64,5 @@ def test_regex_groupdict_success():
 
 def test_regex_groupdict_failure():
     parser = regex_groupdict(r"(?P<year>\d{4})-(?P<month>\d{2})")
-    with pytest.raises(Err):
+    with pytest.raises(ParseError):
         parser.parse("not-a-date")

--- a/tests/test_result.py
+++ b/tests/test_result.py
@@ -1,54 +1,74 @@
 import pytest
 from hypothesis import given, strategies as st
 
-from persil.result import Err, Ok
+from persil.result import Err, Ok, ParseError
+from persil.utils import RowCol
 
 
-def test_ok_or_raise_returns_self():
+def test_ok_returns_self():
     ok = Ok(42, 0)
-    assert ok.ok_or_raise() is ok
+    assert ok.ok() is ok
 
 
-def test_err_ok_or_raise_raises():
-    err = Err(0, ["thing"], "0:0")
-    with pytest.raises(Err):
-        err.ok_or_raise()
+def test_err_ok_raises_parse_error():
+    err = Err(0, frozenset({"thing"}), RowCol(0, 0, 0))
+    with pytest.raises(ParseError):
+        err.ok()
 
 
 def test_err_str_single_expected():
-    err = Err(0, ["integer"], "0:0")
+    err = Err(0, frozenset({"integer"}), RowCol(0, 0, 0))
     assert str(err) == "expected integer at 0:0"
 
 
 def test_err_str_multiple_expected():
-    err = Err(0, ["integer", "string"], "0:0")
+    err = Err(0, frozenset({"integer", "string"}), RowCol(0, 0, 0))
     assert str(err) == "expected one of integer, string at 0:0"
 
 
 def test_err_map_is_noop():
-    err = Err(0, ["thing"], "0:0")
+    err = Err(0, frozenset({"thing"}), RowCol(0, 0, 0))
     assert err.map(lambda x: x + 1) is err
 
 
 def test_err_aggregate_keeps_further_error():
-    # `other` is further into the stream than `self`, so `other`'s
-    # location should be used.
-    earlier = Err(5, ["a"], "0:5")
-    further = Err(3, ["b"], "0:3")
-    result = further.aggregate(earlier)
+    # `other` is further into the stream than `self`, so `other` wins entirely.
+    earlier = Err(3, frozenset({"b"}), RowCol(3, 0, 3))
+    further = Err(5, frozenset({"a"}), RowCol(5, 0, 5))
+    result = earlier.aggregate(further)
 
     assert isinstance(result, Err)
     assert result.index == 5
-    assert result.location == "0:5"
-    assert set(result.expected) == {"a", "b"}
+    assert result.location == RowCol(5, 0, 5)
+    # Only the furthest error's expectations are kept.
+    assert result.expected == frozenset({"a"})
+
+
+def test_err_aggregate_merges_at_same_index():
+    err_a = Err(5, frozenset({"a"}), RowCol(5, 0, 5))
+    err_b = Err(5, frozenset({"b"}), RowCol(5, 0, 5))
+    result = err_a.aggregate(err_b)
+
+    assert isinstance(result, Err)
+    assert result.index == 5
+    assert result.expected == frozenset({"a", "b"})
 
 
 def test_err_aggregate_with_ok_returns_ok():
-    err = Err(0, ["a"], "0:0")
+    err = Err(0, frozenset({"a"}), RowCol(0, 0, 0))
     ok = Ok(42, 5)
     result = err.aggregate(ok)
     assert isinstance(result, Ok)
     assert result.value == 42
+
+
+def test_parse_error_exposes_err_attributes():
+    err = Err(3, frozenset({"x"}), RowCol(3, 1, 0))
+    exc = ParseError(err)
+    assert exc.index == 3
+    assert exc.expected == frozenset({"x"})
+    assert exc.location == RowCol(3, 1, 0)
+    assert "expected x at 1:0" in str(exc)
 
 
 @given(
@@ -79,16 +99,28 @@ def test_ok_map_composition(value: int, index: int):
     assert left.index == right.index
 
 
+def test_err_from_stream_non_text_sequence():
+    """For non-str/bytes sequences, location falls back to the raw index."""
+    err = Err.from_stream(2, "thing", [1, 2, 3])
+    assert err.location == 2
+    assert err.expected == frozenset({"thing"})
+
+
 @given(
     idx_a=st.integers(min_value=0, max_value=1000),
     idx_b=st.integers(min_value=0, max_value=1000),
 )
 def test_aggregate_keeps_furthest_index(idx_a: int, idx_b: int):
     """aggregate always picks the error furthest into the stream."""
-    err_a = Err(idx_a, ["a"], f"0:{idx_a}")
-    err_b = Err(idx_b, ["b"], f"0:{idx_b}")
+    err_a = Err(idx_a, frozenset({"a"}), idx_a)
+    err_b = Err(idx_b, frozenset({"b"}), idx_b)
     result = err_a.aggregate(err_b)
 
     assert isinstance(result, Err)
     assert result.index == max(idx_a, idx_b)
-    assert set(result.expected) == {"a", "b"}
+    if idx_a == idx_b:
+        assert result.expected == frozenset({"a", "b"})
+    elif idx_a > idx_b:
+        assert result.expected == frozenset({"a"})
+    else:
+        assert result.expected == frozenset({"b"})

--- a/tests/test_streaming_api.py
+++ b/tests/test_streaming_api.py
@@ -7,7 +7,7 @@ from hypothesis import strategies as st
 from persil import regex, string
 from persil.stream import Stream, from_stream
 
-from persil.result import Err
+from persil.result import ParseError
 
 year_parser = regex(r"\d{4}").map(int)
 month_parser = regex(r"(?:0\d|1[012])").map(int)
@@ -42,7 +42,7 @@ def test_from_stream_failure_path():
     def must_see_hello(stream: Stream[str]) -> str:
         return stream.apply(string("hello"))
 
-    with pytest.raises(Err):
+    with pytest.raises(ParseError):
         must_see_hello.parse("goodbye")
 
 
@@ -53,8 +53,23 @@ def test_from_stream_with_desc():
 
     assert must_see_hello.parse("hello") == "hello"
 
-    with pytest.raises(Err, match="greeting"):
+    with pytest.raises(ParseError, match="greeting"):
         must_see_hello.parse("goodbye")
+
+
+def test_from_stream_cut_propagates():
+    """A cut() failure inside a from_stream function must propagate as
+    ParseError, not be swallowed as a Backtrack."""
+
+    @from_stream
+    def cut_parser(stream: Stream[str]) -> str:
+        return stream.apply(string("a").cut())
+
+    # The cut makes the error non-backtrackable, so even behind an
+    # alternative the ParseError should propagate.
+    parser = cut_parser | string("b")
+    with pytest.raises(ParseError):
+        parser.parse("x")
 
 
 @given(text=st.from_regex(r"[a-z]+", fullmatch=True))

--- a/tests/test_string.py
+++ b/tests/test_string.py
@@ -1,7 +1,7 @@
 import pytest
 
 from persil import tag
-from persil.result import Err
+from persil.result import ParseError
 
 parser = tag("TeSt", transform=lambda s: s.lower())
 
@@ -18,7 +18,7 @@ def test_string_parser(message: str):
 
 
 def test_transformed_tag_no_match():
-    with pytest.raises(Err):
+    with pytest.raises(ParseError):
         parser.parse("nope")
 
 

--- a/tests/test_until.py
+++ b/tests/test_until.py
@@ -2,7 +2,7 @@ import pytest
 from hypothesis import given, strategies as st
 
 from persil import regex, string
-from persil.result import Err
+from persil.result import ParseError
 
 # Matches any single character, including newlines.
 any_char = regex(r"[\s\S]")
@@ -51,7 +51,7 @@ def test_until_min_satisfied():
 
 def test_until_min_violated():
     # `other` matches after only 1 item, but min=2.
-    with pytest.raises(Err):
+    with pytest.raises(ParseError):
         any_char.until(string("|"), min=2).parse("a|")
 
 
@@ -62,7 +62,7 @@ def test_until_max_satisfied():
 
 def test_until_max_violated():
     # 4 items appear before `other`, but max=3.
-    with pytest.raises(Err):
+    with pytest.raises(ParseError):
         any_char.until(string("|"), max=3).parse("abcd|")
 
 
@@ -73,7 +73,7 @@ def test_until_max_zero():
 
 
 def test_until_max_zero_violated():
-    with pytest.raises(Err):
+    with pytest.raises(ParseError):
         any_char.until(string("|"), max=0).parse("a|")
 
 
@@ -110,7 +110,7 @@ def test_until_max_property(content: str, max_items: int):
         chars = parser.parse(content + "|")
         assert chars == list(content)
     else:
-        with pytest.raises(Err):
+        with pytest.raises(ParseError):
             parser.parse(content + "|")
 
 
@@ -129,5 +129,5 @@ def test_until_min_property(content: str, min_items: int):
         chars = parser.parse(content + "|")
         assert chars == list(content)
     else:
-        with pytest.raises(Err):
+        with pytest.raises(ParseError):
             parser.parse(content + "|")

--- a/tests/test_until_excluding.py
+++ b/tests/test_until_excluding.py
@@ -2,14 +2,14 @@ import pytest
 from hypothesis import given, strategies as st
 
 from persil import regex, string
-from persil.result import Err
+from persil.result import ParseError
 
 any_char = regex(r"[\s\S]")
 
 
 def test_until_excluding_max_exceeded():
     parser = any_char.until_excluding(string("|"), max=2)
-    with pytest.raises(Err, match="at most"):
+    with pytest.raises(ParseError, match="at most"):
         parser.parse_partial("abcd|")
 
 
@@ -18,7 +18,7 @@ def test_until_excluding_min_not_met_inner_fails():
     # `other` matches.
     digit = regex(r"\d")
     parser = digit.until_excluding(string("|"), min=3)
-    with pytest.raises(Err, match="at least"):
+    with pytest.raises(ParseError, match="at least"):
         parser.parse_partial("12x|")
 
 
@@ -27,7 +27,7 @@ def test_until_excluding_other_not_found():
     # "did not find other parser" branch.
     digit = regex(r"\d")
     parser = digit.until_excluding(string("|"), min=0)
-    with pytest.raises(Err):
+    with pytest.raises(ParseError):
         parser.parse_partial("12x")
 
 
@@ -49,7 +49,7 @@ def test_until_excluding_max_property(content: str, max_items: int):
         # Separator must still be in the remainder.
         assert remainder.startswith("|")
     else:
-        with pytest.raises(Err):
+        with pytest.raises(ParseError):
             parser.parse_partial(content + "|")
 
 
@@ -69,5 +69,5 @@ def test_until_excluding_min_property(content: str, min_items: int):
         assert result == list(content)
         assert remainder.startswith("|")
     else:
-        with pytest.raises(Err):
+        with pytest.raises(ParseError):
             parser.parse_partial(content + "|")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,7 +1,7 @@
 import pytest
 from hypothesis import assume, given, strategies as st
 
-from persil.utils import RowCol, line_info, line_info_at
+from persil.utils import RowCol, line_info_at
 
 
 def test_line_info_at_bytes():
@@ -13,11 +13,6 @@ def test_line_info_at_bytes():
 def test_line_info_at_unsupported_type():
     with pytest.raises(TypeError):
         line_info_at([1, 2, 3], 1)
-
-
-def test_line_info_non_string_sequence():
-    # For non-str/bytes sequences, line_info falls back to str(index).
-    assert line_info([1, 2, 3], 2) == "2"
 
 
 @given(


### PR DESCRIPTION
## Summary

- Split `Err` (now a plain dataclass) from `ParseError` (the raised exception), giving callers machine-readable error data (`.index`, `.expected` as `frozenset[str]`, `.location` as `RowCol | int`)
- Fix `Err.aggregate` to only merge expectations at the same stream index — earlier errors no longer pollute the message
- Unify all error construction through `Err.from_stream`
- Rename internal `SoftError` → `Backtrack`
- Rename `ok_or_raise` → `ok`

### Breaking changes

Code that catches `Err` must catch `ParseError` instead. `Err.expected` is now `frozenset[str]`, `Err.location` is now `RowCol | int`.